### PR TITLE
Add dropdownTexture for user theme options

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -200,9 +200,12 @@ const MetadataEditor = createClass({
 		const listThemes = (renderer)=>{
 			return _.map(_.values(mergedThemes[renderer]), (theme)=>{
 				const preview = theme?.thumbnail ? theme.thumbnail : `/themes/${theme.renderer}/${theme.path}/dropdownPreview.png`;
+				const texture = theme?.thumbnail ? theme.thumbnail : `/themes/${theme.renderer}/${theme.path}/dropdownTexture.png`;
 				return <div className='item' key={`${renderer}_${theme.name}`} onClick={()=>this.handleTheme(theme, renderer)} title={''}>
 					{`${renderer} : ${theme.name}`}
-					<img src={`/themes/${theme.renderer}/${theme.path}/dropdownTexture.png`}/>
+					<div className='texture-container'>
+						<img src={`${texture}`}/>
+					</div>
 					<div className='preview'>
 						<h6>{`${theme.name}`} preview</h6>
 						<img src={`${preview}`}/>

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -230,14 +230,23 @@
 					&:hover > .preview {
 						opacity: 1;
 					}
-					>img {
-						mask-image			    : linear-gradient(90deg, transparent, black 20%);
-						-webkit-mask-image	: linear-gradient(90deg, transparent, black 20%);
-				    	position			    : absolute;
-				    	right				      : 0;
-				    	top					      : 0px;
-						width				        : 50%;
-						height				      : 100%;
+					.texture-container {
+						position: absolute;
+						width: 100%;
+						height: 100%;
+						min-height: 100%;
+						top: 0;
+						left: 0;
+						overflow: hidden;
+						> img {
+							mask-image			    : linear-gradient(90deg, transparent, black 20%);
+							-webkit-mask-image	: linear-gradient(90deg, transparent, black 20%);
+							position			    : absolute;
+							right				      : 0;
+							top					      : 0px;
+							width				        : 50%;
+							min-height: 100%;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is my second take with this PR, and i've got it setup right:  it is a PR on your PR https://github.com/naturalcrit/homebrewery/pull/3321, so you could just merge this into it, or copy/paste it directly if you prefer.   

This creates a dropdown menu texture for the themes options based on the user theme thumbnail:

<img width="399" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/a3a5aa3b-c5ad-49a5-bb0f-ef43a855d574">

